### PR TITLE
feat: Add ASCII art banner with color gradient

### DIFF
--- a/src/banner.rs
+++ b/src/banner.rs
@@ -1,0 +1,38 @@
+const LOGO: &[&str] = &[
+    " ██████╗ ██╗ ███████╗ ███╗   ███╗",
+    " ╚══███║ ╚═╝ ██╔════╝ ████╗ ████║",
+    "   ███╔╝ ██╗ ███████╗ ██╔████╔██║",
+    "  ███╔╝  ██║ ╚════██║ ██║╚██╔╝██║",
+    " ██████╗ ██║ ███████║ ██║ ╚═╝ ██║",
+    " ╚═════╝ ╚═╝ ╚══════╝ ╚═╝     ╚═╝",
+];
+
+const COLORS: &[&str] = &[
+    "\x1b[38;5;27m", // blue
+    "\x1b[38;5;33m", // dodger blue
+    "\x1b[38;5;39m", // deep sky blue
+    "\x1b[38;5;44m", // dark turquoise
+    "\x1b[38;5;49m", // spring green
+    "\x1b[38;5;48m", // medium spring green
+];
+
+const RESET: &str = "\x1b[0m";
+
+// Compile-time assertion to ensure LOGO and COLORS have the same length
+const _: () = assert!(
+    LOGO.len() == COLORS.len(),
+    "LOGO and COLORS must have the same length"
+);
+
+pub fn print_banner() {
+    println!();
+    let last = LOGO.len() - 1;
+    for (i, (line, color)) in LOGO.iter().zip(COLORS).enumerate() {
+        if i == last {
+            println!("{color}{line}{RESET}  v{}", env!("CARGO_PKG_VERSION"));
+        } else {
+            println!("{color}{line}{RESET}");
+        }
+    }
+    println!();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod banner;
 mod guake;
 mod ui;
 mod zellij;
@@ -15,6 +16,14 @@ struct Args {
     /// Rename Guake tab to session name on create/attach
     #[arg(long)]
     guake: bool,
+
+    /// Print banner and exit
+    #[arg(long)]
+    banner: bool,
+
+    /// Suppress banner display
+    #[arg(long)]
+    no_banner: bool,
 }
 
 fn is_inside_zellij() -> bool {
@@ -22,6 +31,14 @@ fn is_inside_zellij() -> bool {
 }
 
 fn run(args: &Args) -> Result<()> {
+    if !args.no_banner {
+        banner::print_banner();
+    }
+
+    if args.banner {
+        return Ok(());
+    }
+
     if is_inside_zellij() {
         eprintln!("Already inside a Zellij session. Please run zism from outside Zellij.");
         std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,11 +18,11 @@ struct Args {
     guake: bool,
 
     /// Print banner and exit
-    #[arg(long)]
+    #[arg(long, conflicts_with = "no_banner")]
     banner: bool,
 
     /// Suppress banner display
-    #[arg(long)]
+    #[arg(long, conflicts_with = "banner")]
     no_banner: bool,
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

Display a colorful ASCII art logo with version at startup.

## Reason for change

Cool.

## Changes

- Add options `--banner` `--no-banner`
- `--banner`: When set, only print banner and exit
- `--no-banner`: When set, not print banner and exec main process

## Notes

Example banner:

```txt
 ██████╗ ██╗ ███████╗ ███╗   ███╗
 ╚══███║ ╚═╝ ██╔════╝ ████╗ ████║
   ███╔╝ ██╗ ███████╗ ██╔████╔██║
  ███╔╝  ██║ ╚════██║ ██║╚██╔╝██║
 ██████╗ ██║ ███████║ ██║ ╚═╝ ██║
 ╚═════╝ ╚═╝ ╚══════╝ ╚═╝     ╚═╝  v0.1.1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a colored ASCII art banner that displays by default when running the application
  * Introduced `--banner` and `--no-banner` CLI flags to control banner visibility
  * Banner includes the application version information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->