### PR TITLE
feat: add uninstall script and checksum support for release artifacts

### DIFF
--- a/.cspell/dicts/project.txt
+++ b/.cspell/dicts/project.txt
@@ -6,4 +6,6 @@ rustup
 softprops
 dtolnay
 esac
+elif
 pipefail
+shasum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,23 @@ jobs:
       - name: Package binary
         run: tar czf zism-x86_64-unknown-linux-gnu.tar.gz -C target/x86_64-unknown-linux-gnu/release zism
 
+      - name: Generate checksum
+        run: |
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum zism-x86_64-unknown-linux-gnu.tar.gz > zism-x86_64-unknown-linux-gnu.tar.gz.sha256
+          elif command -v shasum >/dev/null 2>&1; then
+            shasum -a 256 zism-x86_64-unknown-linux-gnu.tar.gz > zism-x86_64-unknown-linux-gnu.tar.gz.sha256
+          else
+            echo "Error: neither sha256sum nor shasum is available." >&2
+            exit 1
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: zism-x86_64-unknown-linux-gnu.tar.gz
+          files: |
+            zism-x86_64-unknown-linux-gnu.tar.gz
+            zism-x86_64-unknown-linux-gnu.tar.gz.sha256
           generate_release_notes: true
 
       - name: Update latest tag

--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ To change the install directory, set `INSTALL_DIR`:
 INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/23prime/zism/latest/install.sh | sh
 ```
 
+## Uninstallation
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/23prime/zism/latest/uninstall.sh | sh
+```
+
+To change the directory to uninstall from, set `INSTALL_DIR`:
+
+```sh
+INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/23prime/zism/latest/uninstall.sh | sh
+```
+
 ## Usage
 
 Run `zism` outside of a Zellij session:

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,16 @@ for cmd in curl tar; do
   fi
 done
 
+# Detect SHA-256 tool
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA256_CMD="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  SHA256_CMD="shasum -a 256"
+else
+  printf "[ERROR] No SHA-256 tool found. Install sha256sum or shasum.\n" >&2
+  exit 1
+fi
+
 # Get latest version from GitHub API
 printf "Fetching latest release...\n"
 response=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest") || {
@@ -29,14 +39,23 @@ fi
 
 printf "Latest version: %s\n" "$tag"
 
-# Download and extract
+# Download and verify
 url="https://github.com/${REPO}/releases/download/${tag}/${ASSET_NAME}"
+checksum_url="${url}.sha256"
 printf "Downloading %s...\n" "$url"
 
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
 curl -fsSL "$url" -o "${tmpdir}/${ASSET_NAME}"
+curl -fsSL "$checksum_url" -o "${tmpdir}/${ASSET_NAME}.sha256"
+
+printf "Verifying checksum...\n"
+(cd "$tmpdir" && $SHA256_CMD -c "${ASSET_NAME}.sha256") || {
+  printf "[ERROR] Checksum verification failed\n" >&2
+  exit 1
+}
+
 tar xzf "${tmpdir}/${ASSET_NAME}" -C "$tmpdir"
 
 # Install

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -eu
+
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+ZISM_BIN="${INSTALL_DIR}/zism"
+
+if [ -f "$ZISM_BIN" ]; then
+  rm -f "$ZISM_BIN"
+  printf "Removed %s\n" "$ZISM_BIN"
+else
+  printf "zism not found at %s\n" "$ZISM_BIN"
+fi
+
+printf "Done.\n"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

Add uninstall script and checksum verification for release artifacts.

## Reason for change

- Users need a way to cleanly uninstall zism
- Release artifacts lacked integrity verification, making it impossible to detect tampering or corruption during download

## Changes

- Add `uninstall.sh` to remove the installed binary
- Add uninstallation section to `README.md`
- Generate `.sha256` checksum files alongside release artifacts in `release.yml`
- Verify checksum in `install.sh` before extracting the downloaded archive

## Notes

N/A