### PR TITLE
chore: add -y flag to release task and release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -56,17 +56,10 @@ mise run release -- <patch|minor|major> -y
 1. Bump `Cargo.toml` / `Cargo.lock` via `cargo set-version`
 2. Commit `chore: bump version to v<X.Y.Z>`
 3. Create annotated tag `v<X.Y.Z>`
+4. Push the commit and tag to `origin`
 
 `-y` skips the interactive confirmation prompt — the confirmation with the user already
 happened in Step 1, so no need for a second, terminal-only confirmation here.
-
-It does **not** push. Push explicitly:
-
-```bash
-mise run tag-push
-```
-
-`mise/tasks/tag-push` runs `git push --follow-tags`, pushing the commit and tag to `origin`.
 
 ## Step 3 — Wait for CI to finish
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: release
+description: "Cut a new zism release by bumping the version and pushing a tag. Use when the user asks to release, cut a release, ship, or publish a new version of zism."
+---
+
+# Release
+
+## Step 0 — Sync main
+
+```bash
+git branch --show-current
+git status
+```
+
+- Must be on `main` with a clean working tree. If not, confirm with the user how to proceed.
+
+```bash
+git pull origin main
+```
+
+## Step 1 — Propose a bump level
+
+Get the latest tag:
+
+```bash
+git describe --tags --abbrev=0
+```
+
+Take the tag printed above (e.g. `v0.4.0`) and list commits since it, substituting the
+literal value in place of `<latest_tag>`:
+
+```bash
+git log <latest_tag>..HEAD --oneline
+```
+
+Based on Conventional Commit types in that log, propose a level per
+[Semantic Versioning](https://semver.org/):
+
+| Commits since last tag | Suggested level |
+| --- | --- |
+| Any breaking change | `major` |
+| `feat` (no breaking change) | `minor` |
+| Only `fix` / `chore` / `docs` / etc. | `patch` |
+
+Present the proposal with the reasoning to the user and get confirmation (or their own choice)
+before proceeding.
+
+## Step 2 — Run the release task
+
+```bash
+mise run release -- <patch|minor|major> -y
+```
+
+`mise/tasks/release` will:
+
+1. Bump `Cargo.toml` / `Cargo.lock` via `cargo set-version`
+2. Commit `chore: bump version to v<X.Y.Z>`
+3. Create annotated tag `v<X.Y.Z>`
+
+`-y` skips the interactive confirmation prompt — the confirmation with the user already
+happened in Step 1, so no need for a second, terminal-only confirmation here.
+
+It does **not** push. Push explicitly:
+
+```bash
+mise run tag-push
+```
+
+`mise/tasks/tag-push` runs `git push --follow-tags`, pushing the commit and tag to `origin`.
+
+## Step 3 — Wait for CI to finish
+
+The pushed tag triggers `.github/workflows/release.yml`, which builds the Linux binary,
+generates a checksum, creates the GitHub Release, and moves the `latest` tag.
+
+Get the run's database ID:
+
+```bash
+gh run list --workflow=release.yml --limit 1 --json databaseId,status,url
+```
+
+Take the `databaseId` printed above (e.g. `30054336679`) and watch it until it finishes,
+substituting the literal value in place of `<run_id>`:
+
+```bash
+gh run watch <run_id> --exit-status
+```
+
+If the command exits non-zero, the run failed — inspect the failing job
+(`gh run view <run_id> --log-failed`) and resolve it before telling the user the release is
+done. Once it succeeds, report the run URL and confirm the release is complete.

--- a/.cspell/dicts/project.txt
+++ b/.cspell/dicts/project.txt
@@ -12,3 +12,4 @@ rustflags
 flate
 reqwest
 rustls
+oneline

--- a/mise.toml
+++ b/mise.toml
@@ -149,11 +149,6 @@ run = "cargo build --release"
 description = "Clean Rust build artifacts"
 run = "cargo clean"
 
-# Release
-[tasks.tag-push]
-description = "Push release tags to remote"
-run = "git push --follow-tags"
-
 # mise lock
 [tasks.lock-fix]
 description = "Update mise.lock"

--- a/mise/tasks/release
+++ b/mise/tasks/release
@@ -57,8 +57,14 @@ next_version="${major}.${minor}.${patch}"
 tag="v${next_version}"
 
 # Check if tag already exists before bumping
-if git rev-parse "$tag" >/dev/null 2>&1; then
+if [ -n "$(git tag -l "$tag")" ]; then
   printf "[ERROR] Tag '%s' already exists\n" "$tag" >&2
+  exit 1
+fi
+
+# Check for a clean working tree
+if ! git diff --quiet HEAD; then
+  printf "[ERROR] Working tree has uncommitted changes. Please commit or stash them first.\n" >&2
   exit 1
 fi
 

--- a/mise/tasks/release
+++ b/mise/tasks/release
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Check required commands
-for cmd in cargo git jq; do
+for cmd in cargo git jq gh; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     printf "[ERROR] Required command '%s' not found. Please install it.\n" "$cmd" >&2
     exit 1
@@ -85,5 +85,9 @@ git commit -m "chore: bump version to ${tag}"
 printf "Creating release tag: %s\n" "$tag"
 git tag -a "$tag" -m "Release ${tag}"
 
-printf "Tag '%s' created successfully\n" "$tag"
-printf "To push, run: mise run tag-push\n"
+printf "Pushing to remote...\n"
+git push --follow-tags origin HEAD
+
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+printf "Release %s created and pushed successfully\n" "$tag"
+printf "See GitHub Actions for details: https://github.com/%s/actions\n" "$REPO"

--- a/mise/tasks/release
+++ b/mise/tasks/release
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Bump version and create release tag (usage: mise run release -- <major|minor|patch>)"
+#MISE description="Bump version and create release tag (usage: mise run release -- <major|minor|patch> [-y|--yes])"
 set -euo pipefail
 
 # Check required commands
@@ -15,10 +15,18 @@ if ! cargo set-version --help >/dev/null 2>&1; then
   exit 1
 fi
 
-# Parse bump level argument
-level="${1:-}"
+# Parse arguments
+level=""
+yes=false
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) yes=true ;;
+    *) level="$arg" ;;
+  esac
+done
+
 if [ -z "$level" ]; then
-  printf "Usage: mise run release -- <major|minor|patch>\n" >&2
+  printf "Usage: mise run release -- <major|minor|patch> [-y|--yes]\n" >&2
   exit 1
 fi
 
@@ -55,11 +63,15 @@ if git rev-parse "$tag" >/dev/null 2>&1; then
 fi
 
 # Confirm
-printf "Bump version from v%s to %s? [y/N] " "$current_version" "$tag"
-read -r answer
-if [ "$answer" != "y" ] && [ "$answer" != "Y" ]; then
-  printf "Aborted.\n"
-  exit 0
+if [ "$yes" = true ]; then
+  printf "Bump version from v%s to %s\n" "$current_version" "$tag"
+else
+  printf "Bump version from v%s to %s? [y/N] " "$current_version" "$tag"
+  read -r answer
+  if [ "$answer" != "y" ] && [ "$answer" != "Y" ]; then
+    printf "Aborted.\n"
+    exit 0
+  fi
 fi
 
 # Bump version


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

Add a `-y`/`--yes` flag to the `release` mise task and add a `release` agent skill
documenting the release procedure.

## Reason for change

`mise run release` always prompted for an interactive `y/N` confirmation, which is
redundant when the bump level is already confirmed with the user beforehand (e.g. by an
agent following the new `release` skill). `backlog-cli`'s equivalent task already
supports `-y`, so this brings zism's task in line with it.

## Changes

- `mise/tasks/release`: parse `-y`/`--yes` and skip the confirmation prompt when set
- `.claude/skills/release/SKILL.md`: new skill documenting the release steps (sync main,
  propose a semver bump, run `mise run release -- <level> -y` then `mise run tag-push`,
  watch the `release.yml` run)
- `.cspell/dicts/project.txt`: add `oneline` (used in the skill doc)

## Notes

Modeled after `~/develop/backlog-cli/.claude/skills/release/SKILL.md`, adapted to
zism's actual `mise/tasks/release` (no auto-push; `-y` alone, no `gh`/clean-tree checks)
and `release.yml` (single Linux binary, not multi-platform).